### PR TITLE
auto-pause-playlist

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1780,3 +1780,47 @@ ImprovedTube.redirectShortsToWatch = function () {
         }
     }
 };
+
+
+/*------------------------------------------------------------------------------
+autoplay pause for next video
+------------------------------------------------------------------------------*/
+function injectAutoPauseToggle() {
+  const controls = document.querySelector('.ytp-right-controls');
+  if (!controls || document.getElementById('auto-pause-toggle')) return;
+
+  const btn = document.createElement('button');
+  btn.id = 'auto-pause-toggle';
+  btn.className = 'ytp-button';
+  btn.title = 'Toggle Auto-Pause Playlist';
+  btn.textContent = '⏸️';
+  btn.style.fontSize = '16px';
+  btn.style.padding = '2px';
+  btn.style.marginLeft = '8px';
+
+  btn.onclick = () => {
+    settings.autoPausePlaylist = !settings.autoPausePlaylist;
+    btn.style.opacity = settings.autoPausePlaylist ? '1.0' : '0.5';
+    saveSettings && saveSettings();
+  };
+
+  btn.style.opacity = settings.autoPausePlaylist ? '1.0' : '0.5';
+  controls.appendChild(btn);
+}
+
+// Call this after player loads
+setTimeout(injectAutoPauseToggle, 2000);
+
+setInterval(() => {
+  const video = document.querySelector('video');
+  if (!video) return;
+
+  const isPlaylist = location.href.includes("list=");
+  const isEnabled = settings.autoPausePlaylist;
+
+  if (isEnabled && isPlaylist && video.duration - video.currentTime < 1) {
+    video.pause();
+  }
+}, 500);
+
+


### PR DESCRIPTION
📌 Feature: Auto-Pause Playlist Videos
This pull request introduces a new feature that automatically pauses a YouTube video just before it ends when it's being played from a playlist. This allows users to read comments or take action before the next video plays automatically.

✅ Key Features
Auto-pause logic: Detects when a video is part of a playlist (list= in URL) and pauses ~1 second before it ends.

Toggle button: Adds a button to the YouTube player UI to enable or disable this feature.

Persistent setting: The toggle state is saved using the extension's settings system.

🛠️ How It Works
Injects a button in the player control bar (near volume/settings).

When the feature is enabled, it monitors the current video.

If the video is in a playlist and close to the end (within 1 second), it pauses the video automatically.

🔄 Fixes
Fixes [#3069](https://github.com/code-charity/youtube/issues/3069)

🙏 Feedback Welcome
Let me know if you'd like me to make any improvements, add icons, use MutationObserver for reliability, or enhance accessibility.